### PR TITLE
prometheus will fail to validate

### DIFF
--- a/src/prometheus-net-core/Internal/AsciiFormatter.cs
+++ b/src/prometheus-net-core/Internal/AsciiFormatter.cs
@@ -13,7 +13,7 @@ namespace Prometheus.Internal
         public static void Format(Stream destination, IEnumerable<MetricFamily> metrics)
         {
             var metricFamilys = metrics.ToArray();
-            using (var streamWriter = new StreamWriter(destination, Encoding.UTF8))
+            using (var streamWriter = new StreamWriter(destination, new UTF8Encoding(false)))
             {
                 streamWriter.NewLine = "\n";
                 foreach (var metricFamily in metricFamilys)


### PR DESCRIPTION
 a metric name that has the BOM UTF8 identifiers